### PR TITLE
Fix deadgrep to work on Windows

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -327,7 +327,7 @@ with Emacs text properties."
 
 (defun deadgrep--format-command (search-term search-type case)
   (format
-   "%s --color=ansi --no-heading --with-filename %s %s %s -- %s"
+   "%s --color=ansi --line-number --no-heading --with-filename %s %s %s -- %s ."
    deadgrep-executable
    (cond
     ((eq search-type 'string)

--- a/deadgrep.el
+++ b/deadgrep.el
@@ -174,7 +174,7 @@ We save the last line here, in case we need to append more text to it.")
   (match-string 1 s))
 
 (defconst deadgrep--filename-regexp
-  (rx bos "\x1b[0m\x1b[35m" (group (+? anything)) "\x1b[")
+  (rx bos "\x1b[0m\x1b[3" (or "5" "6") "m" (group (+? anything)) "\x1b[")
   "Extracts the filename from a ripgrep line with ANSI color sequences.
 We use the color sequences to extract the filename exactly, even
 if the path contains colons.")

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -81,6 +81,15 @@
     (should
      (equal line-num 123))))
 
+(ert-deftest deadgrep--split-line--windows ()
+  (-let* ((raw-line
+           "[0m[36mtest\\deadgrep.el[0m:[0m[32m456[0m:    (when ([0m[31m[1mbuffer-live[0m-p buffer)")
+          ((filename line-num _) (deadgrep--split-line raw-line)))
+    (should
+     (equal filename "test\\deadgrep.el"))
+    (should
+     (equal line-num 456))))
+
 (ert-deftest deadgrep--split-line--propertize ()
   (let* ((raw-line "[0m[31m[1mfoo[0m bar")
          (line (deadgrep--propertize-hits raw-line)))


### PR DESCRIPTION
Since Emacs does not allocate pty on Windows, `ripgrep` tries to search stdin
when search paths are not specified.

Also line number option is not enabled by default if stdout is not a tty.

In addition to that, `ripgrep` uses different colors for filename on Unix and Windows.
https://github.com/BurntSushi/ripgrep/pull/557

Fixes #5 
I tested the change on Windows only.