### PR TITLE
Implement jump commands with "j" prefixed bindings

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -916,6 +916,30 @@ This will either be a button, a filename, or a search result."
 (define-key deadgrep-mode-map (kbd "n") #'deadgrep-forward)
 (define-key deadgrep-mode-map (kbd "p") #'deadgrep-backward)
 
+(defmacro deadgrep--define-jump-command (name heading)
+  "Define an interactive command with NAME that jumps to HEADING."
+  (declare (indent defun))
+  `(defun ,name ()
+     ,(format "Jump to \"%s\"." heading)
+     (interactive)
+     (goto-char (point-min))
+     (when (re-search-forward (concat "^" ,heading ":") nil t)
+       (deadgrep--move t))))
+
+(deadgrep--define-jump-command deadgrep-jump-to-search "Search term")
+(deadgrep--define-jump-command deadgrep-jump-to-type "Search type")
+(deadgrep--define-jump-command deadgrep-jump-to-case "Case")
+(deadgrep--define-jump-command deadgrep-jump-to-context "Context")
+(deadgrep--define-jump-command deadgrep-jump-to-directory "Directory")
+(deadgrep--define-jump-command deadgrep-jump-to-files "Files")
+
+(define-key deadgrep-mode-map (kbd "j s") #'deadgrep-jump-to-search)
+(define-key deadgrep-mode-map (kbd "j t") #'deadgrep-jump-to-type)
+(define-key deadgrep-mode-map (kbd "j c") #'deadgrep-jump-to-case)
+(define-key deadgrep-mode-map (kbd "j x") #'deadgrep-jump-to-context)
+(define-key deadgrep-mode-map (kbd "j d") #'deadgrep-jump-to-directory)
+(define-key deadgrep-mode-map (kbd "j f") #'deadgrep-jump-to-files)
+
 (defun deadgrep--start (search-term search-type case)
   "Start a ripgrep search."
   (setq deadgrep--spinner (spinner-create 'progress-bar t))

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -161,3 +161,32 @@ context arguments to ripgrep."
   "Smoke test."
   (deadgrep "foo")
   (deadgrep-restart))
+
+(ert-deftest deadgrep-jump ()
+  "Ensure we can jump to active button for the respective header."
+  (with-temp-buffer
+    (let ((deadgrep--search-term "foo")
+          (deadgrep--search-type 'string)
+          (deadgrep--search-case 'smart)
+          (deadgrep--context nil)
+          (deadgrep--file-type 'all)
+          (default-directory "/tmp"))
+      (deadgrep--write-heading)
+
+      (deadgrep-jump-to-search)
+      (should (equal (deadgrep--button-label) "change"))
+
+      (deadgrep-jump-to-type)
+      (should (equal (deadgrep--button-label) "words"))
+
+      (deadgrep-jump-to-case)
+      (should (equal (deadgrep--button-label) "sensitive"))
+
+      (deadgrep-jump-to-context)
+      (should (equal (deadgrep--button-label) "before"))
+
+      (deadgrep-jump-to-directory)
+      (should (equal (deadgrep--button-label) "/tmp"))
+
+      (deadgrep-jump-to-files)
+      (should (equal (deadgrep--button-label) "type")))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -17,4 +17,10 @@
 	    (:exclude "*-test.el")
 	    (:report-file "/tmp/undercover-report.json"))
 
+(defun deadgrep--button-label ()
+  "Get button label at point, or nil."
+  (let ((button (button-at (point))))
+    (when button
+      (button-label button))))
+
 ;;; test-helper.el ends here


### PR DESCRIPTION
The commands jumps to the first active button at each heading.

For example, `j s` jumps to `change` button at "Search term", `j d` jumps to directory name.