### PR TITLE
Fix path normalisation for Tramp path

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1154,7 +1154,8 @@ for a string, offering the current word as a default."
     search-term))
 
 (defun deadgrep--normalise-dirname (path)
-  "Expand PATH and ensure that it doesn't end with a slash."
+  "Expand PATH and ensure that it doesn't end with a slash.
+If PATH is remote path, it is not expanded."
   (directory-file-name (if (file-remote-p path)
                            path
                          (let (file-name-handler-alist)
@@ -1162,13 +1163,14 @@ for a string, offering the current word as a default."
 
 (defun deadgrep--lookup-override (path)
   "If PATH is present in `deadgrep-project-root-overrides',
-return the overridden value."
-  (setq path (deadgrep--normalise-dirname path))
-  (let ((override
-         (-first
-          (-lambda ((original . _))
-            (equal (deadgrep--normalise-dirname original) path))
-          deadgrep-project-root-overrides)))
+return the overridden value.
+Otherwise, return PATH as is."
+  (let* ((normalised-path (deadgrep--normalise-dirname path))
+         (override
+          (-first
+           (-lambda ((original . _))
+             (equal (deadgrep--normalise-dirname original) normalised-path))
+           deadgrep-project-root-overrides)))
     (when override
       (setq path (cdr override))
       (unless (stringp path)

--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1155,8 +1155,10 @@ for a string, offering the current word as a default."
 
 (defun deadgrep--normalise-dirname (path)
   "Expand PATH and ensure that it doesn't end with a slash."
-  (let (file-name-handler-alist)
-    (directory-file-name (expand-file-name path))))
+  (directory-file-name (if (file-remote-p path)
+                           path
+                         (let (file-name-handler-alist)
+                           (expand-file-name path)))))
 
 (defun deadgrep--lookup-override (path)
   "If PATH is present in `deadgrep-project-root-overrides',

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -292,3 +292,19 @@ context arguments to ripgrep."
      (equal
       (deadgrep--buffer-position 2 1)
       6))))
+
+(ert-deftest deadgrep--normalise-dirname--local-paths ()
+  (if (eq system-type 'windows-nt)
+      (progn
+        (should (equal (deadgrep--normalise-dirname "c:/foo/bar") "c:/foo/bar"))
+        (should (equal (deadgrep--normalise-dirname "c:/foo/bar/") "c:/foo/bar"))
+        (should (equal (deadgrep--normalise-dirname "c:/foo/bar/../baz") "c:/foo/baz")))
+    (should (equal (deadgrep--normalise-dirname "/foo/bar") "/foo/bar"))
+    (should (equal (deadgrep--normalise-dirname "/foo/bar/") "/foo/bar"))
+    (should (equal (deadgrep--normalise-dirname "/foo/bar/../baz") "/foo/baz"))))
+
+(ert-deftest deadgrep--normalise-dirname--remote-paths ()
+  (should (equal (deadgrep--normalise-dirname "/pscp:localhost:") "/pscp:localhost:"))
+  (should (equal (deadgrep--normalise-dirname "/pscp:localhost:/") "/pscp:localhost:/"))
+  (should (equal (deadgrep--normalise-dirname "/pscp:localhost:/foo/bar") "/pscp:localhost:/foo/bar"))
+  (should (equal (deadgrep--normalise-dirname "/pscp:localhost:/foo/bar/") "/pscp:localhost:/foo/bar")))

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -272,12 +272,18 @@ context arguments to ripgrep."
      (equal
       (deadgrep--lookup-override "/foo/bar")
       "/overridden")))
-  (let* ((deadgrep-project-root-overrides
-          `(("~/foo" . "/overridden"))))
+  (let ((deadgrep-project-root-overrides
+         '(("~/foo" . "/overridden"))))
     (should
      (equal
       (deadgrep--lookup-override (expand-file-name "~/foo"))
-      "/overridden"))))
+      "/overridden")))
+  (let ((deadgrep-project-root-overrides
+         '(("~/foo" . "/overridden"))))
+    (should
+     (equal
+      (deadgrep--lookup-override "~/bar")
+      "~/bar"))))
 
 (ert-deftest deadgrep--buffer-position ()
   (with-temp-buffer


### PR DESCRIPTION
This contains 2 changes.

* `deadgrep--normalise-dirname`: Do not expand path if it is remote.  
  This fixes `/pscp:host:` => `c:/pscp:host:` conversion on Windows.
* `deadgrep--lookup-override`: Do not modify path if it is not overridden.
  This makes unit tests pass on Windows.