### PR TITLE
Fix problem that deadgrep move does not work

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1009,9 +1009,10 @@ in the current buffer."
 
     (point)))
 
-(defun deadgrep--filename ()
-  "Get the filename of the result at point."
-  (get-text-property (line-beginning-position) 'deadgrep-filename))
+(defun deadgrep--filename (&optional pos)
+  "Get the filename of the result at point POS.
+If POS is nil, use the beginning position of the current line."
+  (get-text-property (or pos (line-beginning-position)) 'deadgrep-filename))
 
 (defun deadgrep--line-number ()
   "Get the filename of the result at point."
@@ -1131,7 +1132,7 @@ Keys are interned filenames, so they compare with `eq'.")
 (defun deadgrep--item-p (pos)
   "Is there something at POS that we can interact with?"
   (or (button-at pos)
-      (deadgrep--filename)))
+      (deadgrep--filename pos)))
 
 (defun deadgrep--move (forward-p)
   "Move to the next item.


### PR DESCRIPTION
`n`, `p` do not work since https://github.com/Wilfred/deadgrep/commit/12a146c8d9feffaf1fda3ba3eaa68afb024e41e2#diff-ebaf319cedbc95e2f292132ed2a27a9cR1069