### PR TITLE
Add hook that runs when search is finished

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -239,6 +239,9 @@ It is used to create `imenu' index.")
 
             (setq prev-line-num line-num))))))))
 
+(defvar deadgrep-finished-hook nil
+  "Hook run when `deadgrep' search is finished.")
+
 (defun deadgrep--process-sentinel (process output)
   "Update the deadgrep buffer associated with PROCESS as complete."
   (let ((buffer (process-buffer process))
@@ -262,6 +265,7 @@ It is used to create `imenu' index.")
               (goto-char (point-max))
               (insert output))))
 
+        (run-hooks 'deadgrep-finished-hook)
         (message "Deadgrep finished")))))
 
 (defun deadgrep--process-filter (process output)


### PR DESCRIPTION
I'm writing `deadgrep` support in [wgrep](https://github.com/mhayashi1120/Emacs-wgrep), which could be an alternate solution for #12.

In order to do it, this hook is required to call `wgrep` setup function.
 `deadgrep-mode-hook`  cannot be used since it is not called by `deadgrep-restart` (and search may not be finished when it is called).