### PR TITLE
Add new interactive command deadgrep-kill-all-buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# UNRELEASED
+
+Added command `deadgrep-kill-all-buffers` which kills all open deadgrep
+buffers.
+
 # v0.9
 
 Results buffers are now opened with `switch-to-buffer-other-window`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ or copy it into your `~/.emacs.d`.
 You can also use `M-x imenu` to move between files in a results
 buffer.
 
+### Additional interactive commands
+
+| Name                        | Action                          |
+| ---                         | ---                             |
+| `deadgrep-kill-all-buffers` | Kill all open deadgrep buffers. |
+
 ### Minibuffer
 
 You use the minibuffer to enter a new search term.

--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1485,5 +1485,11 @@ This is intended for use with `next-error-function', which see."
      (format "\nInitial output from ripgrep:\n%S" output)
      (format "\n\nPlease file bugs at https://github.com/Wilfred/deadgrep/issues/new"))))
 
+(defun deadgrep-kill-all-buffers ()
+  "Kill all open deadgrep buffers."
+  (interactive)
+  (dolist (buffer (deadgrep--buffers))
+    (kill-buffer buffer)))
+
 (provide 'deadgrep)
 ;;; deadgrep.el ends here

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -406,3 +406,9 @@ edit mode."
   (should
    (not
     (deadgrep--matches-globs-p "foo.py" '("*.y")))))
+
+(ert-deftest deadgrep-kill-all-buffers--kills-buffers ()
+  (deadgrep--buffer "foo" "/" "blah.el")
+  (deadgrep--buffer "bar" "/" "blah.el")
+  (call-interactively #'deadgrep-kill-all-buffers)
+  (should (not (deadgrep--buffers))))


### PR DESCRIPTION
Feature inspired by the grep-a-lot.el command grep-a-lot-clear-stack.
Source found at:

https://www.emacswiki.org/emacs/grep-a-lot.el

Like many, I do lots and lots of searches throughout the day. After a
while, my buffer list is full of stale unwanted deadgrep buffers. This
new command makes it very simple and efficient to remove these stale
buffers with a single command.

Before switching from grep-a-lot to deadgrep, I used the equivalent
feature frequently.