### PR TITLE
Replace start-file-process-shell-command with start-file-process

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -635,14 +635,6 @@ to obtain ripgrep results."
 
     (nreverse args)))
 
-(defun deadgrep--format-command (search-term search-type case context)
-  "Return a command string that we can execute in a shell
-to obtain ripgrep results."
-  (format
-   "%s %s"
-   deadgrep-executable
-   (s-join " " (deadgrep--arguments search-term search-type case context))))
-
 (defun deadgrep--write-heading ()
   "Write the deadgrep heading with buttons reflecting the current
 search settings."
@@ -1277,14 +1269,16 @@ matches (if the result line has been truncated)."
   (setq deadgrep--spinner (spinner-create 'progress-bar t))
   (setq deadgrep--running t)
   (spinner-start deadgrep--spinner)
-  (let* ((command (deadgrep--format-command
-                   search-term search-type case
-                   deadgrep--context))
+  (let* ((args (deadgrep--arguments
+                search-term search-type case
+                deadgrep--context))
+         (command (format "%s %s" deadgrep-executable (s-join " " args)))
          (process
-          (start-file-process-shell-command
-           (format "rg %s" search-term)
-           (current-buffer)
-           command)))
+          (apply #'start-file-process
+                 (format "rg %s" search-term)
+                 (current-buffer)
+                 deadgrep-executable
+                 args)))
     (setq deadgrep--debug-command command)
     (set-process-filter process #'deadgrep--process-filter)
     (set-process-sentinel process #'deadgrep--process-sentinel)))

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -423,17 +423,17 @@ edit mode."
 (ert-deftest deadgrep--format-command ()
   (should
    (equal (deadgrep--format-command "foo" 'regexp 'smart nil)
-          "rg --color=ansi --line-number --no-heading --with-filename  --smart-case   -- foo ."))
+          "rg --color=ansi --line-number --no-heading --with-filename --smart-case -- foo ."))
 
   (let ((deadgrep--file-type '(type . "elisp")))
     (should
      (equal (deadgrep--format-command "foo" 'string 'sensitive '(1 . 0))
-            "rg --color=ansi --line-number --no-heading --with-filename --fixed-strings --case-sensitive --type elisp --before-context 1 --after-context 0 -- foo .")))
+            "rg --color=ansi --line-number --no-heading --with-filename --fixed-strings --case-sensitive --type=elisp --before-context=1 --after-context=0 -- foo .")))
 
   (let ((deadgrep--file-type '(glob . "*.el")))
     (should
      (equal (deadgrep--format-command "foo" 'words 'ignore '(3 . 2))
-            "rg --color=ansi --line-number --no-heading --with-filename --fixed-strings --word-regexp --ignore-case --type-add 'custom:*.el' --type custom --before-context 3 --after-context 2 -- foo ."))))
+            "rg --color=ansi --line-number --no-heading --with-filename --fixed-strings --word-regexp --ignore-case --type-add=custom:*.el --type=custom --before-context=3 --after-context=2 -- foo ."))))
 
 (ert-deftest deadgrep--format-command-error-cases ()
   (should-error

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -419,3 +419,29 @@ edit mode."
   (deadgrep--buffer "bar" "/" "blah.el")
   (call-interactively #'deadgrep-kill-all-buffers)
   (should (not (deadgrep--buffers))))
+
+(ert-deftest deadgrep--format-command ()
+  (should
+   (equal (deadgrep--format-command "foo" 'regexp 'smart nil)
+          "rg --color=ansi --line-number --no-heading --with-filename  --smart-case   -- foo ."))
+
+  (let ((deadgrep--file-type '(type . "elisp")))
+    (should
+     (equal (deadgrep--format-command "foo" 'string 'sensitive '(1 . 0))
+            "rg --color=ansi --line-number --no-heading --with-filename --fixed-strings --case-sensitive --type elisp --before-context 1 --after-context 0 -- foo .")))
+
+  (let ((deadgrep--file-type '(glob . "*.el")))
+    (should
+     (equal (deadgrep--format-command "foo" 'words 'ignore '(3 . 2))
+            "rg --color=ansi --line-number --no-heading --with-filename --fixed-strings --word-regexp --ignore-case --type-add 'custom:*.el' --type custom --before-context 3 --after-context 2 -- foo ."))))
+
+(ert-deftest deadgrep--format-command-error-cases ()
+  (should-error
+   (deadgrep--format-command "foo" 'foo 'smart nil))
+
+  (should-error
+   (deadgrep--format-command "foo" 'string 'bar '(1 . 0)))
+
+  (let ((deadgrep--file-type '(baz)))
+    (should-error
+     (deadgrep--format-command "foo" 'words 'ignore '(3 . 2)))))

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -420,28 +420,28 @@ edit mode."
   (call-interactively #'deadgrep-kill-all-buffers)
   (should (not (deadgrep--buffers))))
 
-(ert-deftest deadgrep--format-command ()
+(ert-deftest deadgrep--arguments ()
   (should
-   (equal (deadgrep--format-command "foo" 'regexp 'smart nil)
-          "rg --color=ansi --line-number --no-heading --with-filename --smart-case -- foo ."))
+   (equal (deadgrep--arguments "foo" 'regexp 'smart nil)
+          '("--color=ansi" "--line-number" "--no-heading" "--with-filename" "--smart-case" "--" "foo" ".")))
 
   (let ((deadgrep--file-type '(type . "elisp")))
     (should
-     (equal (deadgrep--format-command "foo" 'string 'sensitive '(1 . 0))
-            "rg --color=ansi --line-number --no-heading --with-filename --fixed-strings --case-sensitive --type=elisp --before-context=1 --after-context=0 -- foo .")))
+     (equal (deadgrep--arguments "foo" 'string 'sensitive '(1 . 0))
+            '("--color=ansi" "--line-number" "--no-heading" "--with-filename" "--fixed-strings" "--case-sensitive" "--type=elisp" "--before-context=1" "--after-context=0" "--" "foo" "."))))
 
   (let ((deadgrep--file-type '(glob . "*.el")))
     (should
-     (equal (deadgrep--format-command "foo" 'words 'ignore '(3 . 2))
-            "rg --color=ansi --line-number --no-heading --with-filename --fixed-strings --word-regexp --ignore-case --type-add=custom:*.el --type=custom --before-context=3 --after-context=2 -- foo ."))))
+     (equal (deadgrep--arguments "foo" 'words 'ignore '(3 . 2))
+            '("--color=ansi" "--line-number" "--no-heading" "--with-filename" "--fixed-strings" "--word-regexp" "--ignore-case" "--type-add=custom:*.el" "--type=custom" "--before-context=3" "--after-context=2" "--" "foo" ".")))))
 
-(ert-deftest deadgrep--format-command-error-cases ()
+(ert-deftest deadgrep--arguments-error-cases ()
   (should-error
-   (deadgrep--format-command "foo" 'foo 'smart nil))
+   (deadgrep--arguments "foo" 'foo 'smart nil))
 
   (should-error
-   (deadgrep--format-command "foo" 'string 'bar '(1 . 0)))
+   (deadgrep--arguments "foo" 'string 'bar '(1 . 0)))
 
   (let ((deadgrep--file-type '(baz)))
     (should-error
-     (deadgrep--format-command "foo" 'words 'ignore '(3 . 2)))))
+     (deadgrep--arguments "foo" 'words 'ignore '(3 . 2)))))


### PR DESCRIPTION
This solves 2 problems on Windows host.

* Using `glob` causes error since cmdproxy.exe (Windows default `shell-file-name`) does not handle single quote.
* Using `shell-quote-argument` with Tramp does not always work since it uses local quote for remote.