### PR TITLE
Introduce `deadgrep-display-buffer-function'

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -90,6 +90,13 @@ results buffers.
 In extreme cases (100KiB+ single-line files), we can get a stack
 overflow on our regexp matchers if we don't apply this.")
 
+(defvar deadgrep-display-buffer-function
+  'switch-to-buffer-other-window
+  "Function used to show the deadgrep result buffer.
+
+This function is called with one argument, the results buffer to
+display.")
+
 (defface deadgrep-meta-face
   '((t :inherit font-lock-comment-face))
   "Face used for deadgrep UI text."
@@ -1436,30 +1443,31 @@ don't actually start the search."
         (setq prev-search-type deadgrep--search-type)
         (setq prev-search-case deadgrep--search-case)))
 
-    (switch-to-buffer-other-window buf)
+    (funcall deadgrep-display-buffer-function buf)
 
-    (setq imenu-create-index-function #'deadgrep--create-imenu-index)
-    (setq next-error-function #'deadgrep-next-error)
+    (with-current-buffer buf
+      (setq imenu-create-index-function #'deadgrep--create-imenu-index)
+      (setq next-error-function #'deadgrep-next-error)
 
-    ;; If we have previous search settings, apply them to our new
-    ;; search results buffer.
-    (when last-results-buf
-      (setq deadgrep--search-type prev-search-type)
-      (setq deadgrep--search-case prev-search-case))
+      ;; If we have previous search settings, apply them to our new
+      ;; search results buffer.
+      (when last-results-buf
+        (setq deadgrep--search-type prev-search-type)
+        (setq deadgrep--search-case prev-search-case))
 
-    (deadgrep--write-heading)
+      (deadgrep--write-heading)
 
-    (if current-prefix-arg
-        ;; Don't start the search, just create the buffer and inform
-        ;; the user how to start when they're ready.
-        (progn
-          (setq deadgrep--postpone-start t)
-          (deadgrep--write-postponed))
-      ;; Start the search immediately.
-      (deadgrep--start
-       search-term
-       deadgrep--search-type
-       deadgrep--search-case))))
+      (if current-prefix-arg
+          ;; Don't start the search, just create the buffer and inform
+          ;; the user how to start when they're ready.
+          (progn
+            (setq deadgrep--postpone-start t)
+            (deadgrep--write-postponed))
+        ;; Start the search immediately.
+        (deadgrep--start
+         search-term
+         deadgrep--search-type
+         deadgrep--search-case)))))
 
 (defun deadgrep-next-error (arg reset)
   "Move to the next error.


### PR DESCRIPTION
This variable allows customizing the way the deadgrep result buffer is shown, similar to the way magit and many other utility modes do it. It defaults to the previous function used to display the result buffer.

I think this might address the root cause of #49 (i.e., people want to customize where their rg results are shown) without compromising on any current users' experience.

One thing that was necessary in the same change (since `switch-to-buffer-other-window` also selects the buffer, and that's no longer guaranteed if users customize their buffer display behavior) was that the buffer setup in `deadgrep` had to be wrapped in `with-current-buffer`. I think that's just about right regardless, but let me know if that is not ideal.