### PR TITLE
Enforce no column numbers in rg output

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -619,6 +619,7 @@ to obtain ripgrep results."
     (push "--color=ansi" args)
     (push "--line-number" args)
     (push "--no-heading" args)
+    (push "--no-column" args)
     (push "--with-filename" args)
 
     (cond

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -440,17 +440,17 @@ edit mode."
 (ert-deftest deadgrep--arguments ()
   (should
    (equal (deadgrep--arguments "foo" 'regexp 'smart nil)
-          '("--color=ansi" "--line-number" "--no-heading" "--with-filename" "--smart-case" "--" "foo" ".")))
+          '("--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--smart-case" "--" "foo" ".")))
 
   (let ((deadgrep--file-type '(type . "elisp")))
     (should
      (equal (deadgrep--arguments "foo" 'string 'sensitive '(1 . 0))
-            '("--color=ansi" "--line-number" "--no-heading" "--with-filename" "--fixed-strings" "--case-sensitive" "--type=elisp" "--before-context=1" "--after-context=0" "--" "foo" "."))))
+            '("--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--case-sensitive" "--type=elisp" "--before-context=1" "--after-context=0" "--" "foo" "."))))
 
   (let ((deadgrep--file-type '(glob . "*.el")))
     (should
      (equal (deadgrep--arguments "foo" 'words 'ignore '(3 . 2))
-            '("--color=ansi" "--line-number" "--no-heading" "--with-filename" "--fixed-strings" "--word-regexp" "--ignore-case" "--type-add=custom:*.el" "--type=custom" "--before-context=3" "--after-context=2" "--" "foo" ".")))))
+            '("--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--word-regexp" "--ignore-case" "--type-add=custom:*.el" "--type=custom" "--before-context=3" "--after-context=2" "--" "foo" ".")))))
 
 (ert-deftest deadgrep--arguments-error-cases ()
   (should-error


### PR DESCRIPTION
* This commit allows .ripgreprc to specify --column without breaking
  deadgrep parsing of rg output by making deadgrep call rg with
  --no-column