### PR TITLE
Add the availability for search in ignored files (defaults to false)

### DIFF
--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -466,7 +466,12 @@ edit mode."
   (let ((deadgrep--file-type '(glob . "*.el")))
     (should
      (equal (deadgrep--arguments "foo" 'words 'ignore '(3 . 2))
-            '("--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--word-regexp" "--ignore-case" "--type-add=custom:*.el" "--type=custom" "--before-context=3" "--after-context=2" "--" "foo" ".")))))
+            '("--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--word-regexp" "--ignore-case" "--type-add=custom:*.el" "--type=custom" "--before-context=3" "--after-context=2" "--" "foo" "."))))
+
+  (let ((deadgrep--search-skip-ignored nil))
+    (should
+     (equal (deadgrep--arguments "foo" 'regexp 'smart nil)
+          '("--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--smart-case" "--no-ignore" "--" "foo" ".")))))
 
 (ert-deftest deadgrep--arguments-error-cases ()
   (should-error


### PR DESCRIPTION
It's often useful to search in vendors or ignored files.

This new button allows toggling if the search should search in ignored files.