### PR TITLE
Fix off-by-one in bracket handling in globs

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -509,7 +509,7 @@ with a text face property `deadgrep-match-face'."
             (cl-incf j)
             (setq result (concat result
                                  (substring glob i j)))
-            (setq i (1+ j))))
+            (setq i j)))
          (t
           (setq result (concat result (char-to-string char)))
           (cl-incf i)))))


### PR DESCRIPTION
In particular, recognizes .cpp files as C++. At exit from the while
loop, j points to the closing bracket. The following (cl-incf j) moves
it to the character right after. i should be set to that, and not
bumped one step further.