### PR TITLE
add exec-path and tramp-remote-path in deadgrep-debug.

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1547,6 +1547,10 @@ This is intended for use with `next-error-function', which see."
      (format "Emacs version: %s\n" emacs-version)
      (format "Command: %s\n" command)
      (format "default-directory: %S\n" default-directory)
+     (format "exec-path: %s\n" exec-path)
+     (if (boundp 'tramp-remote-path)
+	 (format "tramp-remote-path: %s\n" tramp-remote-path)
+       "")
      (format "\nInitial output from ripgrep:\n%S" output)
      (format "\n\nPlease file bugs at https://github.com/Wilfred/deadgrep/issues/new"))))
 


### PR DESCRIPTION
Hello, 

I've faced a trouble when I tried to use Deadgrep via Tramp on a remote host where Ripgrep is installed in ~/bin as it wasn't found.

It seems to be good to show the exec-path and tramp-remote-path variable in deadgrep-debug to do debug more easily.

Best regards.
