### PR TITLE
Add `deadgrep-show-heading` option

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -106,6 +106,12 @@ display."
   :type 'function
   :group 'deadgrep)
 
+(defcustom deadgrep-show-heading
+  t
+  "Determines if the search heading should be shown or not."
+  :type 'boolean
+  :group 'deadgrep)
+
 (defface deadgrep-meta-face
   '((t :inherit font-lock-comment-face))
   "Face used for deadgrep UI text."
@@ -1394,7 +1400,7 @@ matches (if the result line has been truncated)."
 
   (let ((start-point (point))
         (inhibit-read-only t))
-    (deadgrep--write-heading)
+    (when deadgrep-show-heading (deadgrep--write-heading))
     ;; If the point was in the heading, ensure that we restore its
     ;; position.
     (goto-char (min (point-max) start-point))
@@ -1547,7 +1553,7 @@ don't actually start the search."
         (setq deadgrep--search-type prev-search-type)
         (setq deadgrep--search-case prev-search-case))
 
-      (deadgrep--write-heading)
+      (when deadgrep-show-heading (deadgrep--write-heading))
 
       (if current-prefix-arg
           ;; Don't start the search, just create the buffer and inform


### PR DESCRIPTION
## Summary

I prefer to see the search results without the default heading and figured others might like the same—relatively simple PR here to add the option to disable the heading.

### Before

<img width="797" alt="image" src="https://user-images.githubusercontent.com/41548458/163937711-7d0e7175-1f93-45a4-a616-65cfd7cfeafc.png">

### After

<img width="797" alt="image" src="https://user-images.githubusercontent.com/41548458/163937811-368dd8ec-5eef-4c61-b6c5-41b8973049b3.png">
