### PR TITLE
Fix collapsing files with context

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -217,7 +217,8 @@ It is used to create `imenu' index.")
                     (s-repeat (log prev-line-num 10) "-")))
             (insert
              (propertize (concat separator "\n")
-                         'face 'deadgrep-meta-face))))
+                         'face 'deadgrep-meta-face
+                         'deadgrep-separator t))))
          ;; If we have a warning or don't have a color code, ripgrep
          ;; must be complaining about something (e.g. zero matches for
          ;; a glob, or permission denied on some directories).
@@ -1230,7 +1231,8 @@ Keys are interned filenames, so they compare with `eq'.")
            (end-pos
             (progn
               (while (and
-                      (get-text-property (point) 'deadgrep-line-number)
+                      (or (get-text-property (point) 'deadgrep-line-number)
+                          (get-text-property (point) 'deadgrep-separator))
                       (not (bobp)))
                 (forward-line))
               ;; Step over the newline.


### PR DESCRIPTION
Minimal repro:

1. search with context
2. try to collapse a file with multiple context blocks
3. only the first context block will be collapsed - due to the context separator line not having the deadgrep-line-number text prop.

This is one potential quick fix.