### PR TITLE
Add options to constrain and broaden files searched 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Starting/stopping a search:
 | <kbd>F</kbd>                  | Cycle through file modes: all, type, glob                               |
 | <kbd>I</kbd>                  | Switch to incremental search, re-running on every keystroke             |
 | <kbd>D</kbd>                  | Change the search directory                                             |
+| <kbd>K</kbd>                  | Cycle through scopes: directory, directory-and-open, open               |
 | <kbd>^</kbd>                  | Re-run the search in the parent directory                               |
 | <kbd>g</kbd>                  | Re-run the search                                                       |
 | <kbd>TAB</kbd>                | Expand/collapse results for a file                                      |

--- a/deadgrep.el
+++ b/deadgrep.el
@@ -994,6 +994,16 @@ Returns a list ordered by the most recently accessed."
    ((eq deadgrep--search-case 'ignore) (setq deadgrep--search-case 'smart)))
   (deadgrep-restart))
 
+(defun deadgrep-cycle-search-scope ()
+  (interactive)
+  (message "cycling")
+  (cond
+   ((eq deadgrep--search-scope 'project) (setq deadgrep--search-scope 'project-open-buffers))
+   ((eq deadgrep--search-scope 'project-open-buffers) (setq deadgrep--search-scope 'open-buffers))
+   ((eq deadgrep--search-scope 'open-buffers) (setq deadgrep--search-scope 'project)))
+  (deadgrep-restart))
+
+
 (defvar deadgrep-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "RET") #'deadgrep-visit-result)
@@ -1004,6 +1014,7 @@ Returns a list ordered by the most recently accessed."
     (define-key map (kbd "T") #'deadgrep-cycle-search-type)
     (define-key map (kbd "C") #'deadgrep-cycle-search-case)
     (define-key map (kbd "F") #'deadgrep-cycle-files)
+    (define-key map (kbd "K") #'deadgrep-cycle-search-scope)
     (define-key map (kbd "D") #'deadgrep-directory)
     (define-key map (kbd "^") #'deadgrep-parent-directory)
     (define-key map (kbd "g") #'deadgrep-restart)

--- a/deadgrep.el
+++ b/deadgrep.el
@@ -725,9 +725,27 @@ to obtain ripgrep results."
 
     (push "--" args)
     (push search-term args)
-    (push "." args)
+    (setq args (append
+                (deadgrep--shell-quote-filenames (deadgrep--files-to-search))
+                args))
+
+    (message (format "searching this: %s" (deadgrep--files-to-search)))
+
 
     (nreverse args)))
+
+(defun deadgrep--files-to-search ()
+  (cond
+   ((eq deadgrep--search-scope 'project) '("."))
+   ((eq deadgrep--search-scope 'project-open-buffers)
+    (deadgrep--filenames-of-open-files-in-project))
+   ((eq deadgrep--search-scope 'open-buffers)
+    (deadgrep--filenames-of-open-files))
+   (t
+    (error "search scope wasn't set correctly!" 'deadgrep--search-scope))))
+
+(defun deadgrep--shell-quote-filenames (filenames)
+  (-map (lambda (filename) (shell-quote-argument filename)) filenames))
 
 (defun deadgrep--write-heading ()
   "Write the deadgrep heading with buttons reflecting the current

--- a/deadgrep.el
+++ b/deadgrep.el
@@ -148,6 +148,8 @@ display."
 (put 'deadgrep--search-case 'permanent-local t)
 (defvar-local deadgrep--file-type 'all)
 (put 'deadgrep--file-type 'permanent-local t)
+(defvar-local deadgrep--search-scope 'project)
+(put 'deadgrep--search-scope 'permanent-local t)
 
 (defvar-local deadgrep--context nil
   "When set, also show context of results.
@@ -440,9 +442,18 @@ with a text face property `deadgrep-match-face'."
   'case nil
   'help-echo "Change case sensitivity")
 
+(define-button-type 'deadgrep-search-scope
+  'action #'deadgrep--search-scope
+  'case nil
+  'help-echo "Change search scope")
+
 (defun deadgrep--case (button)
   (setq deadgrep--search-case (button-get button 'case))
   (deadgrep-restart))
+
+(defun deadgrep--scope (button)
+  (setq deadgrep--search-scope (button-get button 'scope))
+(deadgrep-restart))
 
 (define-button-type 'deadgrep-context
   'action #'deadgrep--context
@@ -767,6 +778,25 @@ search settings."
                 "ignore"
               (deadgrep--button "ignore" 'deadgrep-case
                                 'case 'ignore))
+            "\n"
+
+            (propertize "Scope: "
+                        'face 'deadgrep-meta-face)
+            (if (eq deadgrep--search-scope 'project)
+                "project"
+              (deadgrep--button "project" 'deadgrep-scope
+                                'scope 'project))
+            " "
+            (if (eq deadgrep--search-scope 'project-open-buffers)
+                "project open buffers"
+              (deadgrep--button "project open buffers" 'deadgrep-scope
+                                'scope 'project-open-buffers))
+            " "
+            (if (eq deadgrep--search-scope 'open-buffers)
+                "open buffers"
+              (deadgrep--button "open buffers" 'deadgrep-scope
+                                'scope 'open-buffers))
+
             "\n"
             (propertize "Context: "
                         'face 'deadgrep-meta-face)

--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1687,6 +1687,23 @@ This is intended for use with `next-error-function', which see."
   (dolist (buffer (deadgrep--buffers))
     (kill-buffer buffer)))
 
+(defun deadgrep--filenames-of-open-files ()
+  "Get all open buffers that have a backing file"
+  (-map (lambda (buf)
+          (buffer-file-name buf))
+        (-filter (lambda (buffer) (buffer-file-name buffer))
+                 (buffer-list))))
+
+(defun deadgrep--filenames-of-open-files-in-project ()
+  "Get all buffers that have a backing file in the current project"
+  (let* ((candidates (deadgrep--filenames-of-open-files))
+         (prefix (cdr (project-current))))
+    (-filter (lambda (path)
+               (if (s-starts-with? prefix path)
+                   path
+                 nil))
+             candidates)))
+
 (provide 'deadgrep)
 ;;; deadgrep.el ends here
 


### PR DESCRIPTION
I added some code to cycle between search scopes:

- Searching the currently specified directory.  This is how deadgrep has always worked.
- Limit the search to files that correspond to open buffers in the currently specified directory.
- Expand the search to all files that correspond open buffers, both in and out of the currently specified directory.

I think this is cool.  But here are some problems (that I am willing to address)

- Some of the new code is probably in the wrong place in the `deadgrep.el`
- What this new stuff means probably isn't obvious enough in the UI or the documentation
- My set theory is rusty so I forget what this should be called, but there's a fourth scope that I didn't implement: all files in currently selected directory plus all (other) open files.
- If you're in the "open buffers" scope, then the selected directory is ignored.  The UI should probably reflect this somehow, maybe by greying out `Directory:`.
- `Scope:` in the deadgrep UI should probably be moved to near `Directory:`, probably just above it.