### PR TITLE
Make extra arguments customizable

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -667,16 +667,34 @@ with a text face property `deadgrep-match-face'."
   (setq text (substring-no-properties text))
   (apply #'make-text-button text nil :type type properties))
 
+(defcustom deadgrep-extra-arguments
+  '("--no-config")
+  "List defining extra arguments passed to deadgrep.
+Many arguments are important to how deadgrep parses the output
+and some are added programmatically, like those for search type,
+case sensitivity, and context.
+
+However, some arguments do not fall into either of those cases,
+and they can be added here.  Things like `--search-zip' to search
+compressed files, or `--follow' to follow symlinks.
+
+Sometimes settings in your config file can cause problems, which
+is why `--no-config' is included here by default."
+  :type '(list string)
+  :group 'deadgrep)
+
 (defun deadgrep--arguments (search-term search-type case context)
   "Return a list of command line arguments that we can execute in a shell
 to obtain ripgrep results."
-  (let (args)
+  ;; We put the extra arguments first so that later arguments will
+  ;; override them, preventing a user from accidentally breaking
+  ;; ripgrep by specifying --heading, for example.
+  (let ((args (copy-sequence deadgrep-extra-arguments)))
     (push "--color=ansi" args)
     (push "--line-number" args)
     (push "--no-heading" args)
     (push "--no-column" args)
     (push "--with-filename" args)
-    (push "--no-config" args)
 
     (cond
      ((eq search-type 'string)

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -464,17 +464,17 @@ edit mode."
 (ert-deftest deadgrep--arguments ()
   (should
    (equal (deadgrep--arguments "foo" 'regexp 'smart nil)
-          '("--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--no-config" "--smart-case" "--" "foo" ".")))
+          '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--smart-case" "--" "foo" ".")))
 
   (let ((deadgrep--file-type '(type . "elisp")))
     (should
      (equal (deadgrep--arguments "foo" 'string 'sensitive '(1 . 0))
-            '("--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--no-config" "--fixed-strings" "--case-sensitive" "--type=elisp" "--before-context=1" "--after-context=0" "--" "foo" "."))))
+            '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--case-sensitive" "--type=elisp" "--before-context=1" "--after-context=0" "--" "foo" "."))))
 
   (let ((deadgrep--file-type '(glob . "*.el")))
     (should
      (equal (deadgrep--arguments "foo" 'words 'ignore '(3 . 2))
-            '("--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--no-config" "--fixed-strings" "--word-regexp" "--ignore-case" "--type-add=custom:*.el" "--type=custom" "--before-context=3" "--after-context=2" "--" "foo" ".")))))
+            '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--word-regexp" "--ignore-case" "--type-add=custom:*.el" "--type=custom" "--before-context=3" "--after-context=2" "--" "foo" ".")))))
 
 (ert-deftest deadgrep--arguments-error-cases ()
   (should-error


### PR DESCRIPTION
This allows users to (easily) solve many of their own problems.  For example, I have lots of types in my `~/.ripgreprc` that I don't want to repeat in Emacs, so `--no-config` is very bad for me.  This should also solve #24, #110, and probably others that I have missed.