### PR TITLE
Fix customize type of deadgrep-extra-arguments

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -680,7 +680,7 @@ compressed files, or `--follow' to follow symlinks.
 
 Sometimes settings in your config file can cause problems, which
 is why `--no-config' is included here by default."
-  :type '(list string)
+  :type '(repeat string)
   :group 'deadgrep)
 
 (defun deadgrep--arguments (search-term search-type case context)


### PR DESCRIPTION
I mistakenly thought that `list` meant `repeat`, but when I went to test the customize interface (which I thought I had done, but obviously didn't), it didn't show correctly.  Sorry for the bug.