### PR TITLE
Fix exclude glob patterns

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -721,8 +721,7 @@ to obtain ripgrep results."
      ((eq (car-safe deadgrep--file-type) 'type)
       (push (format "--type=%s" (cdr deadgrep--file-type)) args))
      ((eq (car-safe deadgrep--file-type) 'glob)
-      (push (format "--type-add=custom:%s" (cdr deadgrep--file-type)) args)
-      (push "--type=custom" args))
+      (push (format "--glob=%s" (cdr deadgrep--file-type)) args))
      (t
       (error "Unknown file-type: %S" deadgrep--file-type)))
 

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -474,7 +474,7 @@ edit mode."
   (let ((deadgrep--file-type '(glob . "*.el")))
     (should
      (equal (deadgrep--arguments "foo" 'words 'ignore '(3 . 2))
-            '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--word-regexp" "--ignore-case" "--type-add=custom:*.el" "--type=custom" "--before-context=3" "--after-context=2" "--" "foo" ".")))))
+            '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--word-regexp" "--ignore-case" "--glob=*.el" "--before-context=3" "--after-context=2" "--" "foo" ".")))))
 
 (ert-deftest deadgrep--arguments-error-cases ()
   (should-error


### PR DESCRIPTION
Using glob option passes args to -g/--glob instead of --type-add, which means exclude glob patterns work properly.

Issue: https://github.com/Wilfred/deadgrep/issues/142