### PR TITLE
Only hide a file once

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1262,13 +1262,16 @@ Keys are interned filenames, so they compare with `eq'.")
 (defun deadgrep-toggle-all-file-results ()
   "Show/hide the results of all files."
   (interactive)
-  (let ((should-show (cl-some #'cdr deadgrep--hidden-files)))
+  (let ((should-show (cl-some #'cdr deadgrep--hidden-files))
+        (seen-files nil))
     (save-excursion
       (goto-char (point-min))
       (while (not (eq (point) (point-max)))
         (goto-char (or (next-single-property-change (point) 'deadgrep-filename)
                        (point-max)))
-        (when (deadgrep--filename)
+        (when (and (deadgrep--filename)
+                   (not (member (deadgrep--filename) seen-files)))
+          (push (deadgrep--filename) seen-files)
           (if should-show
               (deadgrep--show)
             (deadgrep--hide)))))))


### PR DESCRIPTION
This seems to fix a problem mentioned by @dolzenko in a comment on #140. The problems seems to be that it hides files multiple times and probably one of the later hides prevents showing with one key stroke.

I tried running cask to run the tests, but it's broken for some reason.  :-( Hopefully, the PR will run the tests for me.