### PR TITLE
Add option to jump to the column of the first match

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1082,6 +1082,13 @@ underlying file."
   :type 'hook
   :group 'deadgrep)
 
+(defcustom deadgrep-jump-to-match-column nil
+  "If non-nil, deadgrep will jump to the column of the first match.
+Otherwise, deadgrep will jump to the column matching the point in the
+*deadgrep ...* buffer."
+  :type 'hook
+  :group 'deadgrep)
+
 (defun deadgrep-edit-mode ()
   "Major mode for editing the results files directly from a
 deadgrep results buffer.
@@ -1203,7 +1210,8 @@ If POS is nil, use the beginning position of the current line."
          (file-name (deadgrep--filename))
          (line-number (deadgrep--line-number))
          (column-offset (when line-number (deadgrep--current-column)))
-         (match-positions (when line-number (deadgrep--match-positions))))
+         (match-positions (when line-number (deadgrep--match-positions)))
+         (match-column (when match-positions (caar match-positions))))
     (when file-name
       (when overlay-arrow-position
         (set-marker overlay-arrow-position nil))
@@ -1218,7 +1226,10 @@ If POS is nil, use the beginning position of the current line."
 
       (when line-number
         (-let [destination-pos (deadgrep--buffer-position
-                                line-number column-offset)]
+                                line-number
+                                (if deadgrep-jump-to-match-column
+                                    match-column
+                                  column-offset))]
           ;; Put point on the position of the match, widening the
           ;; buffer if necessary.
           (when (or (< destination-pos (point-min))


### PR DESCRIPTION
This adds an option to jump to the column of the first match instead of the column of the point.  Personally, I thought it was just a feature that hadn't been implemented since I don't find the current behavior useful, though it was obviously intentional.

I made the default nil so that the behavior doesn't change by default.

The name could probably use some help.  I'm happy to make whatever changes you would like.

This fixes #112.