### PR TITLE
Fix trailing whitespace after skip .gitignore items

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -877,7 +877,6 @@ search settings."
             " "
             (deadgrep--button ".gitignore items" 'deadgrep-vcs-skip-type)
             (if deadgrep--skip-if-vcs-ignore ":yes" ":no")
-            " "
             "\n\n")
     (put-text-property
      start-pos (point)


### PR DESCRIPTION
I have the global setting to show trailing whitespace as "redish". The patch just removes the trailing space.
<img width="574" alt="Screenshot 2024-10-29 at 23 40 04" src="https://github.com/user-attachments/assets/2b0f277f-0dde-4fa7-9c54-a867cc3180c7">
