### PR TITLE
Add functions to increment/decrement context

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -482,6 +482,39 @@ with a text face property `deadgrep-match-face'."
 
   (deadgrep-restart))
 
+(defun deadgrep--update-context (which-context value)
+  "Update the context WHICH-CONTEXT of deadgrep--context by VALUE.
+
+WHICH-CONTEXT is a string, either 'before' or 'after'"
+  (let ((before (or (car deadgrep--context) 0))
+        (after (or (cdr deadgrep--context) 0)))
+    (if (cond
+         ((and (string= which-context "before") (> (+ before value) -1))
+          (setq deadgrep--context (cons (+ before value) after)))
+         ((and (string= which-context "after") (> (+ after value) -1))
+          (setq deadgrep--context (cons before (+ after value)))))
+        (deadgrep-restart))))
+
+(defun deadgrep-increment-before-context ()
+  "Increment context before."
+  (interactive)
+  (deadgrep--update-context "before" 1))
+
+(defun deadgrep-decrement-before-context ()
+  "Decrement context before."
+  (interactive)
+  (deadgrep--update-context "before" -1))
+
+(defun deadgrep-increment-after-context ()
+  "Increment context after."
+  (interactive)
+  (deadgrep--update-context "after" 1))
+
+(defun deadgrep-decrement-after-context ()
+  "Increment context after."
+  (interactive)
+  (deadgrep--update-context "after" -1))
+
 (defun deadgrep--type-list ()
   "Query the rg executable for available file types."
   (let* ((output (with-output-to-string


### PR DESCRIPTION
Thanks for this great package, I use it daily!

I wanted to be able to increase/decrease the before/after context via keybindings rather than clicking through the buttons in the header of a deadgrep buffer. I didn't see a way to do this with the functions `deadgrep` currently exposes, so I wrote my own. I figure others might find this useful, so this PR includes that code.

(Please let me know if I've missed something and this functionality already exists).

## New Functions

`deadgrep--update-context` does most of the work. It takes a string  (`which-context`, which can be either "before" or "after") and an integer (`value`). The function updates the context denoted by `which-context` by adding `value` to the appropriate field in `deadgrep--context`, after ensuring that doing so won't result in a negative value.

A family of interactive functions named `deadgrep-<increment/decrement>-<before/after>-context` are implemented to use `deadgrep--update-context` to increment/decrement the before/after context by 1 line. These are intended to be bound to keys.

## Keybindings
I've not added any keybindings to the `deadgrep-mode-map`, but in my configuration I use the following hydra:

```
(defhydra deadgrep-context ()
                 "context"
                 ("B" deadgrep-increment-before-context "increment before context")
                 ("b" deadgrep-decrement-before-context "decrement before context")
                 ("A" deadgrep-increment-after-context "increment after context")
                 ("a" deadgrep-decrement-after-context "decrement after context"))
```

I'm happy to add default keybindings if that is desired and suggestions are welcome for such keybinds.


_Note: This is my first non-trivial elisp contribution to an emacs package, so please let me know if there's anything here that needs to be changed, I'm happy to do it._