### PR TITLE
WIP: Transient interface for Deadgrep

### DIFF
--- a/Cask
+++ b/Cask
@@ -2,6 +2,8 @@
 (source gnu)
 
 (package-file "deadgrep.el")
+(files "deadgrep-transient.el")
+(depends-on "transient")
 
 (development
  (depends-on "f")

--- a/Cask
+++ b/Cask
@@ -3,7 +3,7 @@
 
 (package-file "deadgrep.el")
 (files "deadgrep-transient.el")
-(depends-on "transient")
+(depends-on "transient" "0.6")
 
 (development
  (depends-on "f")

--- a/README.md
+++ b/README.md
@@ -168,12 +168,32 @@ navigate to the file itself from the file headings.
 
 ## Beta Features
 
+### Edit the results buffers
+
 You can now edit files directly from results buffers with `M-x
 deadgrep-edit-mode`.
 
 It is currently in beta. Alternatively, package [wgrep](https://github.com/mhayashi1120/Emacs-wgrep)
 added support for editing deadgrep buffers in April 2023 via [wgrep-deadgrep](https://melpa.org/#/wgrep-deadgrep).
 (One feature unlocked that way is, e.g., the ability to delete a line in edit mode via `C-d`)
+
+### Transient menu
+
+Deadgrep has an optional menu interface built with [transient](https://github.com/magit/transient).
+After loading `deadgrep-transient`, the menu can be opened by <kbd>t</kbd> in the results buffers.
+Or `M-x deadgrep-transient-menu` opens the menu from anywhere.
+
+It is currently in beta, as all the arguments in the menu are not corresponding to deadgrep options.
+
+You can add extra arguments by the transient API in the follow example.
+
+``` emacs-lisp
+(require 'deadgrep-transient)
+
+(transient-append-suffix 'deadgrep-transient-menu "-g" '("-L" "Follow" "--follow"))
+
+(transient-append-suffix 'deadgrep-transient-menu '(1) ["Input Options" ("-z" "Search Zip" "--search-zip")])
+```
 
 ## Alternative Projects
 

--- a/deadgrep-transient.el
+++ b/deadgrep-transient.el
@@ -119,9 +119,9 @@
 (defun deadgrep-transient-restart ()
   "Restart deadgrep search with new options."
   (interactive)
-  (let ((deadgrep--arguments-function #'deadgrep-transient--arguments))
+  (let ((deadgrep--arguments-function #'deadgrep-transient--arguments)
+        (deadgrep--write-heading-function #'deadgrep-transient--write-heading))
     (setq default-directory deadgrep-transient-directory)
-    (deadgrep-transient--set-options transient-current-suffixes)
     (rename-buffer
      (deadgrep--buffer-name deadgrep--search-term default-directory)
      t)
@@ -138,10 +138,7 @@
   "Search in the current directory using transient arguments."
   (interactive)
   (let* ((deadgrep--arguments-function #'deadgrep-transient--arguments)
-         (deadgrep--write-heading-function
-          (lambda ()
-            (deadgrep-transient--set-options transient-current-suffixes)
-            (deadgrep--write-heading)))
+         (deadgrep--write-heading-function #'deadgrep-transient--write-heading)
          (deadgrep-project-root-function (lambda () deadgrep-transient-directory)))
     (call-interactively #'deadgrep)))
 
@@ -217,6 +214,11 @@
     (push search-term args)
     (push "." args)
     (nreverse args)))
+
+(defun deadgrep-transient--write-heading ()
+  "Write the deadgrep heading with buttons reflecting the current transient settings."
+  (deadgrep-transient--set-options transient-current-suffixes)
+  (deadgrep--write-heading))
 
 (defun deadgrep-transient--read-file-type (_prompt _initial-input _history)
   "Read file type for `deadgrep-transient:--file-type'."

--- a/deadgrep-transient.el
+++ b/deadgrep-transient.el
@@ -209,7 +209,7 @@
     (push "--no-heading" args)
     (push "--no-column" args)
     (push "--with-filename" args)
-    (setq args (nconc (transient-args 'deadgrep-transient) args))
+    (setq args (nconc (transient-args 'deadgrep-transient-menu) args))
     (push "--" args)
     (push search-term args)
     (push "." args)
@@ -226,8 +226,8 @@
 (defclass deadgrep-transient-prefix (transient-prefix)
   ())
 
-(transient-define-prefix deadgrep-transient ()
-  "Start a ripgrep search"
+(transient-define-prefix deadgrep-transient-menu ()
+  "Deadgrep transient menu."
   :class 'deadgrep-transient-prefix
   ["Search Options"
    (deadgrep-transient:--fixed-strings)
@@ -270,7 +270,7 @@
                   (push arg globs)))
                (t (push arg args))))))))
 
-(define-key deadgrep-mode-map "t" #'deadgrep-transient)
+(define-key deadgrep-mode-map "t" #'deadgrep-transient-menu)
 
 (provide 'deadgrep-transient)
 ;;; deadgrep-transient.el ends here

--- a/deadgrep-transient.el
+++ b/deadgrep-transient.el
@@ -147,6 +147,7 @@
 
 (defun deadgrep-transient--set-options (suffixes)
   "Set deadgrep options from transient SUFFIXES."
+  (setq deadgrep--context nil)
   (setq deadgrep--search-case 'sensitive)
   (setq deadgrep--search-type 'regexp)
   (setq deadgrep--file-type 'all)

--- a/deadgrep-transient.el
+++ b/deadgrep-transient.el
@@ -96,6 +96,7 @@
   ())
 
 (cl-defmethod transient-init-value ((obj deadgrep-transient-directory-variable))
+  "Initialize `deadgrep-transient' directory OBJ by `deadgrep-project-root-function'."
   (funcall (oref obj set-value)
            (oref obj variable)
            (oset obj value (if deadgrep--search-term
@@ -103,6 +104,7 @@
                              (funcall deadgrep-project-root-function)))))
 
 (cl-defmethod transient-format-value ((obj deadgrep-transient-directory-variable))
+  "Format `deadgrep-transient' directory OBJ with abbreviation."
   (propertize (prin1-to-string (abbreviate-file-name (oref obj value)))
               'face 'transient-value))
 
@@ -220,7 +222,8 @@
   (deadgrep--read-file-type (buffer-file-name)))
 
 (defun deadgrep-transient--read-glob (prompt initial-input history)
-  "Read glob pattern for `deadgrep-transient:--glob'."
+  "Read glob pattern for `deadgrep-transient:--glob'.
+PROMPT, INITIAL-INPUT and HISTORY are passed to `completing-read-multiple'."
   (completing-read-multiple prompt nil nil nil initial-input history))
 
 (defclass deadgrep-transient-prefix (transient-prefix)
@@ -252,6 +255,7 @@
    ("n" "New search" deadgrep-transient-search)])
 
 (cl-defmethod transient-init-value ((obj deadgrep-transient-prefix))
+  "Initialize `deadgrep-transient' OBJ from `deadgrep--arguments'."
   (let ((orig-args (deadgrep--arguments
                     deadgrep--search-term
                     deadgrep--search-type

--- a/deadgrep-transient.el
+++ b/deadgrep-transient.el
@@ -1,0 +1,242 @@
+;;; deadgrep-transient.el --- Transient interface for deadgrep  -*- lexical-binding: t; -*-
+
+;; URL: https://github.com/Wilfred/deadgrep
+;; Version: 0.1
+;; Package-Requires: ((emacs "25.1") (transient "0.6"))
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Perform deadgrep searches with transient interface.
+
+;; Install from MELPA, then `M-x deadgrep-transient' will do a search!
+
+;;; Code:
+
+(require 'deadgrep)
+(require 'transient)
+
+(transient-define-infix deadgrep-transient:--after-context ()
+  :description "After context"
+  :class 'transient-option
+  :key "-A"
+  :argument "--after-context="
+  :reader 'transient-read-number-N+)
+
+(transient-define-infix deadgrep-transient:--before-context ()
+  :description "Before context"
+  :class 'transient-option
+  :key "-B"
+  :argument "--before-context="
+  :reader 'transient-read-number-N+)
+
+(transient-define-infix deadgrep-transient:--fixed-strings ()
+  :description "String match"
+  :class 'transient-switch
+  :key "-F"
+  :argument "--fixed-strings")
+
+(transient-define-infix deadgrep-transient:--word-regexp ()
+  :description "Word match"
+  :class 'transient-switch
+  :key "-w"
+  :argument "--word-regexp")
+
+(transient-define-infix deadgrep-transient:--*-case ()
+  :description "Search case"
+  :class 'transient-switches
+  :key "=c"
+  :argument-format "--%s"
+  :argument-regexp "\\(--\\(smart-case\\|case-sensitive\\|ignore-case\\)\\)"
+  :choices '("smart-case" "case-sensitive" "ignore-case"))
+
+(transient-define-infix deadgrep-transient:--type ()
+  :description "File type"
+  :class 'transient-option
+  :key "-t"
+  :argument "--type="
+  :reader 'deadgrep-transient--read-file-type)
+
+(transient-define-infix deadgrep-transient:--glob ()
+  :description "File glob"
+  :class 'transient-option
+  :key "-g"
+  :argument "--glob="
+  :reader 'deadgrep-transient--read-glob
+  :multi-value 'repeat)
+
+(transient-define-infix deadgrep-transient:--hidden ()
+  :description "Search hidden"
+  :class 'transient-switch
+  :key "-."
+  :argument "--hidden")
+
+(transient-define-infix deadgrep-transient:--no-ignore-vcs ()
+  :description "No VCS ignore"
+  :class 'transient-switch
+  :key "=v"
+  :argument "--no-ignore-vcs")
+
+(defun deadgrep-transient-restart ()
+  (interactive)
+  (let ((deadgrep--arguments-function #'deadgrep-transient--arguments))
+    (deadgrep-transient--set-options transient-current-suffixes)
+    (deadgrep-restart)))
+
+(defun deadgrep-transient-search ()
+  "Search in the project root directory using transient arguments."
+  (interactive)
+  (let* ((deadgrep--arguments-function #'deadgrep-transient--arguments)
+         (deadgrep--write-heading-function
+          (lambda ()
+            (deadgrep-transient--set-options transient-current-suffixes)
+            (deadgrep--write-heading))))
+    (call-interactively #'deadgrep)))
+
+(defun deadgrep-transient--set-options (suffixes)
+  "Set deadgrep options from transient SUFFIXES."
+  (setq deadgrep--search-case 'sensitive)
+  (setq deadgrep--search-type 'regexp)
+  (setq deadgrep--file-type 'all)
+
+  (let ((after-context 0) (before-context 0) word-regexp)
+    (dolist (suffix suffixes)
+      (pcase (oref suffix :command)
+        ('deadgrep-transient:--after-context
+         (-when-let (value (oref suffix value))
+           (setq after-context (string-to-number value))))
+        ('deadgrep-transient:--before-context
+         (-when-let (value (oref suffix value))
+           (setq before-context (string-to-number value))))
+
+        ('deadgrep-transient:--fixed-strings
+         (when (transient-infix-value suffix)
+           (if word-regexp
+               (setq deadgrep--search-type 'words)
+             (setq deadgrep--search-type 'string))))
+
+        ('deadgrep-transient:--word-regexp
+         (when (transient-infix-value suffix)
+           (setq word-regexp t)
+           (when (eq deadgrep--search-type 'string)
+             (setq deadgrep--search-type 'words))))
+
+        ('deadgrep-transient:--*-case
+         (-when-let (value (cdr (assoc (transient-infix-value suffix)
+                                       '(("--case-sensitive" . sensitive)
+                                         ("--ignore-case" . ignore)
+                                         ("--smart-case" . smart)))))
+           (setq deadgrep--search-case value)))
+
+        ('deadgrep-transient:--glob
+         ;; Skip "!/.git"
+         (-when-let (glob (--first (not (string= it "!/.git")) (oref suffix value)))
+           (setq deadgrep--file-type (cons 'glob glob))))
+
+        ('deadgrep-transient:--type
+         (-when-let (value (oref suffix value))
+           (setq deadgrep--file-type (cons 'type value))))
+
+        ('deadgrep-transient:--hidden
+         (setq deadgrep--skip-if-hidden (not (oref suffix value))))
+
+        ('deadgrep-transient:--no-ignore-vcs
+         (if (oref suffix value)
+             (progn
+               (setq deadgrep--skip-if-vcs-ignore nil)
+               (when (eq deadgrep--file-type 'all)
+                 (setq deadgrep--file-type '(glob . "!/.git"))))
+           (setq deadgrep--skip-if-vcs-ignore t)))))
+
+    (when (or (/= before-context 0) (/= after-context 0))
+      (setq deadgrep--context (cons before-context after-context)))))
+
+(defun deadgrep-transient-search-in-current ()
+  "Search the current directory using transient arguments."
+  (interactive)
+  (let ((deadgrep-project-root-function (lambda () default-directory)))
+    (call-interactively #'deadgrep-transient-search)))
+
+(defun deadgrep-transient--arguments (search-term &optional _search-type _case _context)
+  "Format ripgrep command using SEARCH-TERM."
+  (let ((args (copy-sequence deadgrep-extra-arguments)))
+    (push "--color=ansi" args)
+    (push "--line-number" args)
+    (push "--no-heading" args)
+    (push "--no-column" args)
+    (push "--with-filename" args)
+    (setq args (nconc (transient-args 'deadgrep-transient) args))
+    (push "--" args)
+    (push search-term args)
+    (push "." args)
+    (nreverse args)))
+
+(defun deadgrep-transient--read-file-type (_prompt _initial-input _history)
+  "Read file type for `deadgrep-transient:--file-type'."
+  (deadgrep--read-file-type (buffer-file-name)))
+
+(defun deadgrep-transient--read-glob (prompt initial-input history)
+  "Read glob pattern for `deadgrep-transient:--glob'."
+  (completing-read-multiple prompt nil nil nil initial-input history))
+
+(defclass deadgrep-transient-prefix (transient-prefix)
+  ())
+
+(transient-define-prefix deadgrep-transient ()
+  "Start a ripgrep search"
+  :class 'deadgrep-transient-prefix
+  ["Search Options"
+   (deadgrep-transient:--fixed-strings)
+   (deadgrep-transient:--word-regexp)
+   (deadgrep-transient:--*-case)
+   ]
+  ["Filter Options"
+   (deadgrep-transient:--type)
+   (deadgrep-transient:--glob)
+   (deadgrep-transient:--hidden)
+   (deadgrep-transient:--no-ignore-vcs)
+   ]
+  ["Output Options"
+   (deadgrep-transient:--before-context)
+   (deadgrep-transient:--after-context)
+   ]
+  ["Search"
+   ("r" "Restart search" deadgrep-transient-restart :if (lambda () deadgrep--search-term))
+   ("g" "Search in project root" deadgrep-transient-search)
+   ("c" "Search in current directory" deadgrep-transient-search-in-current)])
+
+(cl-defmethod transient-init-value ((obj deadgrep-transient-prefix))
+  (let ((orig-args (deadgrep--arguments
+                    deadgrep--search-term
+                    deadgrep--search-type
+                    deadgrep--search-case
+                    deadgrep--context))
+        (args '())
+        (globs '()))
+    (oset obj value
+          (catch 'break
+            (dolist (arg orig-args)
+              (cond
+               ((equal arg "--")
+                (throw 'break (append globs args)))
+               ((string-prefix-p "--glob=" arg)
+                (unless (member arg globs)
+                  (push arg globs)))
+               (t (push arg args))))))))
+
+(define-key deadgrep-mode-map "t" #'deadgrep-transient)
+
+(provide 'deadgrep-transient)
+;;; deadgrep-transient.el ends here

--- a/deadgrep.el
+++ b/deadgrep.el
@@ -85,6 +85,19 @@ This affects the behaviour of `deadgrep--project-root', so this
 variable has no effect if you change
 `deadgrep-project-root-function'.")
 
+(defvar deadgrep--arguments-function #'deadgrep--arguments
+  "Function to generate ripgrep command line arguments.
+
+The function should take 4 arguments,
+search term, search type, case and context.
+And it should return a list of argument strings.")
+
+(defvar deadgrep--write-heading-function #'deadgrep--write-heading
+  "Function to write ripgrep heading text.
+
+The function should not take any argument.
+And its return value is not used.")
+
 (defvar deadgrep-history
   nil
   "A list of the previous search terms.")
@@ -1504,9 +1517,9 @@ matches (if the result line has been truncated)."
   (setq deadgrep--running t)
   (setq deadgrep--result-count 0)
   (spinner-start deadgrep--spinner)
-  (let* ((args (deadgrep--arguments
-                search-term search-type case
-                deadgrep--context))
+  (let* ((args (funcall deadgrep--arguments-function
+                        search-term search-type case
+                        deadgrep--context))
          (process
           (apply #'start-file-process
                  (format "rg %s" search-term)
@@ -1553,7 +1566,7 @@ matches (if the result line has been truncated)."
 
   (let ((start-point (point))
         (inhibit-read-only t))
-    (deadgrep--write-heading)
+    (funcall deadgrep--write-heading-function)
     ;; If the point was in the heading, ensure that we restore its
     ;; position.
     (goto-char (min (point-max) start-point))
@@ -1728,7 +1741,7 @@ don't actually start the search."
         (setq deadgrep--skip-if-hidden prev-skip-if-hidden)
         (setq deadgrep--skip-if-vcs-ignore prev-skip-if-vcs-ignore))
 
-      (deadgrep--write-heading)
+      (funcall deadgrep--write-heading-function)
 
       (if current-prefix-arg
           ;; Don't start the search, just create the buffer and inform

--- a/test/deadgrep-transient-test.el
+++ b/test/deadgrep-transient-test.el
@@ -56,7 +56,13 @@
      (list
       (deadgrep-transient-test-create-option 'deadgrep-transient:--before-context "4")
       (deadgrep-transient-test-create-option 'deadgrep-transient:--after-context "3")))
-    (should (equal deadgrep--context '(4 . 3)))))
+    (should (equal deadgrep--context '(4 . 3)))
+
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--before-context)
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--after-context)))
+    (should (null deadgrep--context))))
 
 (ert-deftest deadgrep-transient--set-options-with-search-type ()
   (with-temp-buffer

--- a/test/deadgrep-transient-test.el
+++ b/test/deadgrep-transient-test.el
@@ -1,0 +1,349 @@
+(require 'deadgrep-transient)
+
+(defconst deadgrep-transient-test-base-args
+  '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename")
+  "Base arguments for `deadgrep-transient' test.")
+
+(defun deadgrep-transient-test-create-option (command &optional value)
+  (let ((infix (transient-option :command command)))
+    (when value (oset infix value value))
+    infix))
+
+(defun deadgrep-transient-test-create-switch (command &optional value)
+  (let ((infix (transient-switch :command command)))
+    (when value (oset infix value value))
+    infix))
+
+(defun deadgrep-transient-test-create-switches (command &optional value)
+  (let ((infix (transient-switches :command command)))
+    (when value (oset infix value value))
+    infix))
+
+(ert-deftest deadgrep-transient--set-options-with-default ()
+  (with-temp-buffer
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--after-context)
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--before-context)
+      (deadgrep-transient-test-create-switch 'deadgrep-transient:--fixed-strings)
+      (deadgrep-transient-test-create-switch 'deadgrep-transient:--word-regexp)
+      (deadgrep-transient-test-create-switches 'deadgrep-transient:--*-case)
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--glob)
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--type)
+      (deadgrep-transient-test-create-switch 'deadgrep-transient:--hidden)
+      (deadgrep-transient-test-create-switch 'deadgrep-transient:--no-ignore-vcs)))
+
+    (should (null deadgrep--context))
+    (should (equal deadgrep--search-type 'regexp))
+    (should (equal deadgrep--search-case 'sensitive))
+    (should (eq deadgrep--file-type 'all))
+    (should (eq deadgrep--skip-if-hidden t))
+    (should (eq deadgrep--skip-if-vcs-ignore t))))
+
+(ert-deftest deadgrep-transient--set-options-with-context ()
+  (with-temp-buffer
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--before-context "2")))
+    (should (equal deadgrep--context '(2 . 0)))
+
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--after-context "1")))
+    (should (equal deadgrep--context '(0 . 1)))
+
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--before-context "4")
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--after-context "3")))
+    (should (equal deadgrep--context '(4 . 3)))))
+
+(ert-deftest deadgrep-transient--set-options-with-search-type ()
+  (with-temp-buffer
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-switches 'deadgrep-transient:--fixed-strings
+                                               "--fixed-strings")))
+    (should (equal deadgrep--search-type 'string))
+
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-switches 'deadgrep-transient:--fixed-strings
+                                               "--fixed-strings")
+      (deadgrep-transient-test-create-switches 'deadgrep-transient:--word-regexp
+                                               "--word-regexp")))
+    (should (equal deadgrep--search-type 'words))
+
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-switches 'deadgrep-transient:--word-regexp
+                                               "--word-regexp")))
+    ;; no equivalent value in `deadgrep--search-type'.
+    (should (equal deadgrep--search-type 'regexp))))
+
+(ert-deftest deadgrep-transient--set-options-with-case ()
+  (with-temp-buffer
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-switches 'deadgrep-transient:--*-case
+                                               "--case-sensitive")))
+    (should (equal deadgrep--search-case 'sensitive))
+
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-switches 'deadgrep-transient:--*-case
+                                               "--ignore-case")))
+    (should (equal deadgrep--search-case 'ignore))
+
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-switches 'deadgrep-transient:--*-case
+                                               "--smart-case")))
+    (should (equal deadgrep--search-case 'smart))))
+
+(ert-deftest deadgrep-transient--set-options-with-glob ()
+  (with-temp-buffer
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--glob '("*.el"))))
+    (should (equal deadgrep--file-type '(glob . "*.el")))))
+
+(ert-deftest deadgrep-transient--set-options-with-type ()
+  (with-temp-buffer
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-option 'deadgrep-transient:--type "elisp")))
+    (should (equal deadgrep--file-type '(type . "elisp")))))
+
+(ert-deftest deadgrep-transient--set-options-with-hidden ()
+  (with-temp-buffer
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-switch 'deadgrep-transient:--hidden t)))
+    (should (not deadgrep--skip-if-hidden))))
+
+(ert-deftest deadgrep-transient--set-options-with-no-ignore-vcs ()
+  (with-temp-buffer
+    (deadgrep-transient--set-options
+     (list
+      (deadgrep-transient-test-create-switch 'deadgrep-transient:--no-ignore-vcs t)))
+    (should (not deadgrep--skip-if-vcs-ignore))))
+
+(ert-deftest deadgrep-transient--arguments-with-default ()
+  (with-temp-buffer
+    (let ((deadgrep-extra-arguments '("--no-config")))
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--hidden"
+                        "--glob=!/.git"
+                        "--smart-case"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        ".")))))))
+
+(ert-deftest deadgrep-transient--arguments-with-after-context ()
+  (with-temp-buffer
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
+           (transient-current-command 'deadgrep-transient)
+           (deadgrep-extra-arguments '("--no-config"))
+           (suffix (--first (eq (oref it command) 'deadgrep-transient:--after-context)
+                            transient-current-suffixes)))
+      (oset suffix value "3")
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--after-context=3"
+                        "--hidden"
+                        "--glob=!/.git"
+                        "--smart-case"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        ".")))))))
+(ert-deftest deadgrep-transient--arguments-with-before-context ()
+  (with-temp-buffer
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
+           (transient-current-command 'deadgrep-transient)
+           (deadgrep-extra-arguments '("--no-config"))
+           (suffix (--first (eq (oref it command) 'deadgrep-transient:--before-context)
+                            transient-current-suffixes)))
+      (oset suffix value "10")
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--before-context=10"
+                        "--hidden"
+                        "--glob=!/.git"
+                        "--smart-case"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        ".")))))))
+
+(ert-deftest deadgrep-transient--arguments-without-fixed-strings ()
+  (with-temp-buffer
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
+           (transient-current-command 'deadgrep-transient)
+           (deadgrep-extra-arguments '("--no-config"))
+           (suffix (--first (eq (oref it command) 'deadgrep-transient:--fixed-strings)
+                            transient-current-suffixes)))
+      (oset suffix value nil)
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--hidden"
+                        "--glob=!/.git"
+                        "--smart-case"
+                        "--"
+                        "foo"
+                        ".")))))))
+
+(ert-deftest deadgrep-transient--arguments-with-word-regexp ()
+  (with-temp-buffer
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
+           (transient-current-command 'deadgrep-transient)
+           (deadgrep-extra-arguments '("--no-config"))
+           (suffix (--first (eq (oref it command) 'deadgrep-transient:--word-regexp)
+                            transient-current-suffixes)))
+      (oset suffix value "--word-regexp")
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--hidden"
+                        "--glob=!/.git"
+                        "--smart-case"
+                        "--word-regexp"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        ".")))))))
+
+(ert-deftest deadgrep-transient--arguments-with-type ()
+  (with-temp-buffer
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
+           (transient-current-command 'deadgrep-transient)
+           (deadgrep-extra-arguments '("--no-config"))
+           (suffix (--first (eq (oref it command) 'deadgrep-transient:--type)
+                            transient-current-suffixes)))
+      (oset suffix value "org")
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--hidden"
+                        "--glob=!/.git"
+                        "--type=org"
+                        "--smart-case"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        ".")))))))
+
+(ert-deftest deadgrep-transient--arguments-with-case-sensitive ()
+  (with-temp-buffer
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
+           (transient-current-command 'deadgrep-transient)
+           (deadgrep-extra-arguments '("--no-config"))
+           (suffix (--first (eq (oref it command) 'deadgrep-transient:--*-case)
+                            transient-current-suffixes)))
+      (oset suffix value "--case-sensitive")
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--hidden"
+                        "--glob=!/.git"
+                        "--case-sensitive"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        ".")))))))
+
+(ert-deftest deadgrep-transient--arguments-with-ignore-case ()
+  (with-temp-buffer
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
+           (transient-current-command 'deadgrep-transient)
+           (deadgrep-extra-arguments '("--no-config"))
+           (suffix (--first (eq (oref it command) 'deadgrep-transient:--*-case)
+                            transient-current-suffixes)))
+      (oset suffix value "--ignore-case")
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--hidden"
+                        "--glob=!/.git"
+                        "--ignore-case"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        ".")))))))
+
+(ert-deftest deadgrep-transient--arguments-with-glob ()
+  (with-temp-buffer
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
+           (transient-current-command 'deadgrep-transient)
+           (deadgrep-extra-arguments '("--no-config"))
+           (suffix (--first (eq (oref it command) 'deadgrep-transient:--glob)
+                            transient-current-suffixes)))
+      (oset suffix value (list "*.org"))
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--hidden"
+                        "--glob=*.org"
+                        "--smart-case"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        "."))))
+
+      (oset suffix value (list "*.el" "*.org"))
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--hidden"
+                        "--glob=*.org"
+                        "--glob=*.el"
+                        "--smart-case"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        ".")))))))
+
+(ert-deftest deadgrep-transient--arguments-without-hidden ()
+  (with-temp-buffer
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
+           (transient-current-command 'deadgrep-transient)
+           (deadgrep-extra-arguments '("--no-config"))
+           (suffix (--first (eq (oref it command) 'deadgrep-transient:--hidden)
+                            transient-current-suffixes)))
+      (oset suffix value nil)
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--glob=!/.git"
+                        "--smart-case"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        ".")))))))
+
+(ert-deftest deadgrep-transient--arguments-with-no-ignore-vcs ()
+  (with-temp-buffer
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
+           (transient-current-command 'deadgrep-transient)
+           (deadgrep-extra-arguments '("--no-config"))
+           (suffix (--first (eq (oref it command) 'deadgrep-transient:--no-ignore-vcs)
+                            transient-current-suffixes)))
+      (oset suffix value "--no-ignore-vcs")
+      (should (equal (deadgrep-transient--arguments "foo")
+                     (append
+                      deadgrep-transient-test-base-args
+                      '("--no-ignore-vcs"
+                        "--hidden"
+                        "--glob=!/.git"
+                        "--smart-case"
+                        "--fixed-strings"
+                        "--"
+                        "foo"
+                        ".")))))))

--- a/test/deadgrep-transient-test.el
+++ b/test/deadgrep-transient-test.el
@@ -145,8 +145,8 @@
 
 (ert-deftest deadgrep-transient--arguments-with-after-context ()
   (with-temp-buffer
-    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
-           (transient-current-command 'deadgrep-transient)
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient-menu))
+           (transient-current-command 'deadgrep-transient-menu)
            (deadgrep-extra-arguments '("--no-config"))
            (suffix (--first (eq (oref it command) 'deadgrep-transient:--after-context)
                             transient-current-suffixes)))
@@ -164,8 +164,8 @@
                         ".")))))))
 (ert-deftest deadgrep-transient--arguments-with-before-context ()
   (with-temp-buffer
-    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
-           (transient-current-command 'deadgrep-transient)
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient-menu))
+           (transient-current-command 'deadgrep-transient-menu)
            (deadgrep-extra-arguments '("--no-config"))
            (suffix (--first (eq (oref it command) 'deadgrep-transient:--before-context)
                             transient-current-suffixes)))
@@ -184,8 +184,8 @@
 
 (ert-deftest deadgrep-transient--arguments-without-fixed-strings ()
   (with-temp-buffer
-    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
-           (transient-current-command 'deadgrep-transient)
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient-menu))
+           (transient-current-command 'deadgrep-transient-menu)
            (deadgrep-extra-arguments '("--no-config"))
            (suffix (--first (eq (oref it command) 'deadgrep-transient:--fixed-strings)
                             transient-current-suffixes)))
@@ -202,8 +202,8 @@
 
 (ert-deftest deadgrep-transient--arguments-with-word-regexp ()
   (with-temp-buffer
-    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
-           (transient-current-command 'deadgrep-transient)
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient-menu))
+           (transient-current-command 'deadgrep-transient-menu)
            (deadgrep-extra-arguments '("--no-config"))
            (suffix (--first (eq (oref it command) 'deadgrep-transient:--word-regexp)
                             transient-current-suffixes)))
@@ -222,8 +222,8 @@
 
 (ert-deftest deadgrep-transient--arguments-with-type ()
   (with-temp-buffer
-    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
-           (transient-current-command 'deadgrep-transient)
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient-menu))
+           (transient-current-command 'deadgrep-transient-menu)
            (deadgrep-extra-arguments '("--no-config"))
            (suffix (--first (eq (oref it command) 'deadgrep-transient:--type)
                             transient-current-suffixes)))
@@ -242,8 +242,8 @@
 
 (ert-deftest deadgrep-transient--arguments-with-case-sensitive ()
   (with-temp-buffer
-    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
-           (transient-current-command 'deadgrep-transient)
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient-menu))
+           (transient-current-command 'deadgrep-transient-menu)
            (deadgrep-extra-arguments '("--no-config"))
            (suffix (--first (eq (oref it command) 'deadgrep-transient:--*-case)
                             transient-current-suffixes)))
@@ -261,8 +261,8 @@
 
 (ert-deftest deadgrep-transient--arguments-with-ignore-case ()
   (with-temp-buffer
-    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
-           (transient-current-command 'deadgrep-transient)
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient-menu))
+           (transient-current-command 'deadgrep-transient-menu)
            (deadgrep-extra-arguments '("--no-config"))
            (suffix (--first (eq (oref it command) 'deadgrep-transient:--*-case)
                             transient-current-suffixes)))
@@ -280,8 +280,8 @@
 
 (ert-deftest deadgrep-transient--arguments-with-glob ()
   (with-temp-buffer
-    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
-           (transient-current-command 'deadgrep-transient)
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient-menu))
+           (transient-current-command 'deadgrep-transient-menu)
            (deadgrep-extra-arguments '("--no-config"))
            (suffix (--first (eq (oref it command) 'deadgrep-transient:--glob)
                             transient-current-suffixes)))
@@ -312,8 +312,8 @@
 
 (ert-deftest deadgrep-transient--arguments-without-hidden ()
   (with-temp-buffer
-    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
-           (transient-current-command 'deadgrep-transient)
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient-menu))
+           (transient-current-command 'deadgrep-transient-menu)
            (deadgrep-extra-arguments '("--no-config"))
            (suffix (--first (eq (oref it command) 'deadgrep-transient:--hidden)
                             transient-current-suffixes)))
@@ -330,8 +330,8 @@
 
 (ert-deftest deadgrep-transient--arguments-with-no-ignore-vcs ()
   (with-temp-buffer
-    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient))
-           (transient-current-command 'deadgrep-transient)
+    (let* ((transient-current-suffixes (transient-suffixes 'deadgrep-transient-menu))
+           (transient-current-command 'deadgrep-transient-menu)
            (deadgrep-extra-arguments '("--no-config"))
            (suffix (--first (eq (oref it command) 'deadgrep-transient:--no-ignore-vcs)
                             transient-current-suffixes)))

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -464,17 +464,17 @@ edit mode."
 (ert-deftest deadgrep--arguments ()
   (should
    (equal (deadgrep--arguments "foo" 'regexp 'smart nil)
-          '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--smart-case" "--" "foo" ".")))
+          '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--smart-case" "--hidden" "--glob=!/.git" "--" "foo" ".")))
 
   (let ((deadgrep--file-type '(type . "elisp")))
     (should
      (equal (deadgrep--arguments "foo" 'string 'sensitive '(1 . 0))
-            '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--case-sensitive" "--type=elisp" "--before-context=1" "--after-context=0" "--" "foo" "."))))
+            '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--case-sensitive" "--type=elisp" "--before-context=1" "--after-context=0" "--hidden" "--glob=!/.git" "--" "foo" "."))))
 
   (let ((deadgrep--file-type '(glob . "*.el")))
     (should
      (equal (deadgrep--arguments "foo" 'words 'ignore '(3 . 2))
-            '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--word-regexp" "--ignore-case" "--glob=*.el" "--before-context=3" "--after-context=2" "--" "foo" ".")))))
+            '("--no-config" "--color=ansi" "--line-number" "--no-heading" "--no-column" "--with-filename" "--fixed-strings" "--word-regexp" "--ignore-case" "--glob=*.el" "--before-context=3" "--after-context=2" "--hidden" "--glob=!/.git" "--" "foo" ".")))))
 
 (ert-deftest deadgrep--arguments-error-cases ()
   (should-error


### PR DESCRIPTION
### Summary

Hi, this PR provides [transient](https://github.com/magit/transient) interface for deadgrep.
This makes it easy to add new options to deadgrep through the transient API.
I'd like to hear your opinion whether it can be included in deadgrep.

Ref. #125

![image](https://github.com/user-attachments/assets/97291100-34f5-43cb-9b98-7efa66625193)

For example, we can add `--search-zip` options like the following. Ref. #110

```emacs-lisp
(transient-append-suffix 'deadgrep-transient-menu '(1) ["Input Options" ("-z" "Search Zip" "--search-zip")])
```

![image](https://github.com/user-attachments/assets/d78da470-747b-445b-8b53-324efe77d2f7)

### Changes

* Introduce new file and command `deadgrep-transient-menu`, which invokes transient menu for deadgrep.
* Bind <kbd>t</kbd> to `deadgrep-transient-menu` in `deadgrep-mode-map`.
* Add new internal variables `deadgrep--arguments-function` and `deadgrep--write-heading-function`,
  which are default to `deadgrep--arguments` and `deadgrep--write-heading` respectively and overridden in deadgrep-transient.

### TODO

This PR is a draft due to the following reasons.

* [x] ~~No document. README.md is not updated yet.~~
* [x] ~~This currently provides 2 transient suffixes, "Search in project root" and "Search in current directory",~~
  ~~but I am considering if it is better to add transient infix to set the search directory instead.~~
* [ ] The transient interface is corresponding to ripgrep options, while deadgrep options have some shorthand.
  So deadgrep-transient options cannot be translated to deadgrep options in some cases.
  For example, it is possible that "--word-regexp" is on and "--fixed-strings" is off in deadgrep-transient, while there is no corresponding option in deadgrep.
  We might add some optional text in deadgrep heading for them.

Correspondence between some of deadgrep options and ripgrep options.

| variable                     | value  | deadgrep UI | ripgrep options               |
| ---                          | ---    | ---         | ---                           |
| deadgrep--search-type        | string | string      | --fixed-strings               |
|                              | words  | words       | --fixed-strings --word-regexp |
|                              | regexp | regexp      |                               |
| deadgrep--skip-if-hidden     | t      | yes         |                               |
|                              | nil    | no          | --hidden                      |
| deadgrep--skip-if-vcs-ignore | t      | yes         | --glob=!/.git                 |
|                              | nil    | no          | --no-ignore-vcs               |
