### PR TITLE
Address review feedback on context increment/decrement helpers

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -483,37 +483,38 @@ with a text face property `deadgrep-match-face'."
   (deadgrep-restart))
 
 (defun deadgrep--update-context (which-context value)
-  "Update the context WHICH-CONTEXT of deadgrep--context by VALUE.
+  "Update the context WHICH-CONTEXT of `deadgrep--context' by VALUE.
 
-WHICH-CONTEXT is a string, either 'before' or 'after'"
+WHICH-CONTEXT is a symbol, either \\='before or \\='after."
   (let ((before (or (car deadgrep--context) 0))
         (after (or (cdr deadgrep--context) 0)))
-    (if (cond
-         ((and (string= which-context "before") (> (+ before value) -1))
-          (setq deadgrep--context (cons (+ before value) after)))
-         ((and (string= which-context "after") (> (+ after value) -1))
-          (setq deadgrep--context (cons before (+ after value)))))
-        (deadgrep-restart))))
+    (cond
+     ((and (eq which-context 'before) (> (+ before value) -1))
+      (setq deadgrep--context (cons (+ before value) after))
+      (deadgrep-restart))
+     ((and (eq which-context 'after) (> (+ after value) -1))
+      (setq deadgrep--context (cons before (+ after value)))
+      (deadgrep-restart)))))
 
 (defun deadgrep-increment-before-context ()
   "Increment context before."
   (interactive)
-  (deadgrep--update-context "before" 1))
+  (deadgrep--update-context 'before 1))
 
 (defun deadgrep-decrement-before-context ()
   "Decrement context before."
   (interactive)
-  (deadgrep--update-context "before" -1))
+  (deadgrep--update-context 'before -1))
 
 (defun deadgrep-increment-after-context ()
   "Increment context after."
   (interactive)
-  (deadgrep--update-context "after" 1))
+  (deadgrep--update-context 'after 1))
 
 (defun deadgrep-decrement-after-context ()
-  "Increment context after."
+  "Decrement context after."
   (interactive)
-  (deadgrep--update-context "after" -1))
+  (deadgrep--update-context 'after -1))
 
 (defun deadgrep--type-list ()
   "Query the rg executable for available file types."


### PR DESCRIPTION
Follow-up to #161, applying the review feedback left on that PR:

- **Use `cond` directly** rather than nesting it inside an `if`. The `deadgrep-restart` call now lives inside each matching branch, which preserves the original behaviour (only restart when the context actually changes) without relying on the `setq` return value as the `if` condition.
- **Use the symbols `'before` / `'after`** instead of strings, matching the existing `deadgrep--context` button handler that already dispatches on the `before`/`after` symbols via `cl-case`. The docstring is updated to match.
- **Fix the `deadgrep-decrement-after-context` docstring**, which previously read "Increment context after."

No behavioural change beyond the docstring fix — purely a style/consistency cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146BcDvXCLTfdcXE3KFoWL3

---
_Generated by [Claude Code](https://claude.ai/code/session_0146BcDvXCLTfdcXE3KFoWL3)_