### PR TITLE
Fix infinite loop in deadgrep-next-error when moving backward

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1789,7 +1789,7 @@ This is intended for use with `next-error-function', which see."
 
     (while (and
             (not (zerop arg))
-            (not (eobp)))
+            (if direction (not (eobp)) (not (bobp))))
       (if direction
           (forward-line 1)
         (forward-line -1))

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -325,6 +325,20 @@ context arguments to ripgrep."
     (deadgrep--glob-regexp "[?]")
     "^[?]$")))
 
+(ert-deftest deadgrep-next-error--backward-at-first-result ()
+  "Moving backward from the first result should terminate rather
+than looping forever."
+  (with-temp-deadgrep-buf
+   ;; Move point to the first result line.
+   (goto-char (point-max))
+   (deadgrep-backward-match)
+   (beginning-of-line)
+   ;; `previous-error' calls `next-error-function' with a negative
+   ;; argument. There are no results before point, so this should
+   ;; simply stop at the beginning of the buffer.
+   (deadgrep-next-error -1 nil)
+   (should (bobp))))
+
 (ert-deftest deadgrep--create-imenu-index ()
   (with-temp-buffer
     (deadgrep--insert-output "\


### PR DESCRIPTION
`deadgrep-next-error`'s line-walking loop only checked for end-of-buffer, so calling `previous-error` (which invokes `next-error-function` with a negative argument) when there were no result lines before point kept calling `(forward-line -1)` at the beginning of the buffer forever, hanging Emacs until `C-g`. Reproduced by putting point on the first result and running `M-x previous-error`.

The fix stops at beginning-of-buffer when moving backward, mirroring the existing end-of-buffer check for forward movement. Includes a regression test, which hangs the suite without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwUBSSJnCtCeoqJEA3xH48