### PR TITLE
Fix error on backspace in deadgrep-incremental with empty search term

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1624,6 +1624,7 @@ for a string, offering the current word as a default."
     search-term))
 
 (defun deadgrep-incremental ()
+  "Read a search term interactively, updating the results after every keystroke."
   (interactive)
   (catch 'break
     (let ((deadgrep--incremental-active t)
@@ -1639,7 +1640,8 @@ for a string, offering the current word as a default."
            ((eq next-char ?\C-m)
             (throw 'break nil))
            ((eq next-char ?\C-?)
-            (setq search-term (s-left -1 search-term)))
+            (unless (s-blank? search-term)
+              (setq search-term (substring search-term 0 -1))))
            (t
             (setq search-term (concat search-term (list next-char))))))
         (when (> (length search-term) 2)


### PR DESCRIPTION
Pressing backspace in `deadgrep-incremental` when the search term is empty (before typing anything, or after deleting the whole term) signalled `args-out-of-range`, because `(s-left -1 "")` calls `(substring "" 0 -1)`. Backspace is now a no-op when the term is already empty; deleting the last character uses a plain `substring`.

Also adds the missing docstring to `deadgrep-incremental`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwUBSSJnCtCeoqJEA3xH48