### PR TITLE
Escape regexp metacharacters when converting globs to regexps

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -600,7 +600,7 @@ WHICH-CONTEXT is a symbol, either \\='before or \\='after."
                                  (substring glob i j)))
             (setq i j)))
          (t
-          (setq result (concat result (char-to-string char)))
+          (setq result (concat result (regexp-quote (char-to-string char))))
           (cl-incf i)))))
     (concat result "$")))
 

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -323,7 +323,24 @@ context arguments to ripgrep."
   (should
    (string=
     (deadgrep--glob-regexp "[?]")
-    "^[?]$")))
+    "^[?]$"))
+  ;; Characters that are regexp metacharacters but not glob
+  ;; metacharacters should be treated literally.
+  (should
+   (string=
+    (deadgrep--glob-regexp "*.h++")
+    "^.*\\.h\\+\\+$")))
+
+(ert-deftest deadgrep--matches-glob-p--regexp-metachars ()
+  "Globs containing regexp metacharacters should be matched literally."
+  (should
+   (deadgrep--matches-globs-p "foo.h++" '("*.h++")))
+  (should
+   (not
+    (deadgrep--matches-globs-p "foo.h" '("*.h++"))))
+  (should
+   (not
+    (deadgrep--matches-globs-p "foo.hh" '("*.h++")))))
 
 (ert-deftest deadgrep--create-imenu-index ()
   (with-temp-buffer


### PR DESCRIPTION
`deadgrep--glob-regexp` copied literal glob characters into the elisp regexp verbatim, so a glob containing regexp metacharacters matched the wrong files: `*.h++` produced `^.*\.h++$`, which matches `foo.h` and `foo.hh` but *not* `foo.h++`. Since this function backs `deadgrep--relevant-file-type`, it could make deadgrep suggest the wrong default file type.

Literal characters are now passed through `regexp-quote`. Existing glob metacharacter handling (`*`, `?`, `.`, `[...]`) is unchanged and still covered by the existing tests; new tests cover the metacharacter case.

(Current ripgrep's `--type-list` happens to contain no globs with regexp metacharacters, so this is mostly a latent bug — but older rg versions and user-defined types can hit it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwUBSSJnCtCeoqJEA3xH48