### PR TITLE
Fix context separator width for small and round line numbers

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -226,7 +226,7 @@ It is used to create `imenu' index.")
             ;; line numbers.
             (when prev-line-num
               (setq separator
-                    (s-repeat (log prev-line-num 10) "-")))
+                    (s-repeat (length (number-to-string prev-line-num)) "-")))
             (insert
              (propertize (concat separator "\n")
                          'face 'deadgrep-meta-face

--- a/test/deadgrep-unit-test.el
+++ b/test/deadgrep-unit-test.el
@@ -325,6 +325,21 @@ context arguments to ripgrep."
     (deadgrep--glob-regexp "[?]")
     "^[?]$")))
 
+(ert-deftest deadgrep--insert-output--context-separator ()
+  "The -- separator between context groups should match the width
+of the previous line number, even for single-digit line numbers."
+  (with-temp-buffer
+    (deadgrep--insert-output
+     (concat
+      "\033[0m\033[35mf.txt\033[0m:\033[0m\033[32m1\033[0m:\033[0m\033[1m\033[31mhit\033[0m\n"
+      "--\n"
+      "\033[0m\033[35mf.txt\033[0m:\033[0m\033[32m9\033[0m:\033[0m\033[1m\033[31mhit\033[0m\n")
+     t)
+    (should
+     (equal
+      (buffer-substring-no-properties (point-min) (point-max))
+      "f.txt\n1    hit\n-\n9    hit\n"))))
+
 (ert-deftest deadgrep--create-imenu-index ()
   (with-temp-buffer
     (deadgrep--insert-output "\


### PR DESCRIPTION
The `--` separator between context groups sizes itself to the previous line number, but used `(log prev-line-num 10)`:

- after line 1 the separator was **empty** (log 1 = 0), leaving a blank line;
- after exact powers of 10 it was one dash short (log 100 = 2.0 for a 3-digit number);
- it also relied on `s-repeat` quietly accepting a float.

Use the digit count of the line number instead. Includes a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwUBSSJnCtCeoqJEA3xH48