### PR TITLE
Replace if-let with dash's -if-let

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1311,7 +1311,7 @@ If POS is nil, use the beginning position of the current line."
         ;; position on the line, go the first match. This is generally
         ;; what users want, especially when there are long lines.
         (unless column-offset
-          (if-let (first-match-pos (car match-positions))
+          (-if-let (first-match-pos (car match-positions))
               (setq column-offset (car first-match-pos))
             (setq column-offset 0)))
 


### PR DESCRIPTION
`deadgrep--visit-result` uses `if-let`, which lives in `subr-x` — a feature deadgrep never `require`s. It has worked by accident (newer Emacsen preload it, or another library loads it first), and `if-let` is declared obsolete in Emacs 31 in favour of `if-let*`, which doesn't exist on Emacs 25 (the minimum supported version).

Switching to dash's `-if-let` sidesteps both problems: dash is already a hard dependency, and the file already uses `-when-let` elsewhere. No user-visible behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwUBSSJnCtCeoqJEA3xH48