### PR TITLE
Bump ripgrep used in CI from 12.1.1 to 13.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
     - uses: conao3/setup-cask@master
 
     - name: Download ripgrep
-      run: curl -LO https://github.com/BurntSushi/ripgrep/releases/download/12.1.1/ripgrep_12.1.1_amd64.deb
+      run: curl -LO https://github.com/BurntSushi/ripgrep/releases/download/13.0.0/ripgrep_13.0.0_amd64.deb
     - name: Install ripgrep
-      run: sudo dpkg -i ripgrep_12.1.1_amd64.deb
+      run: sudo dpkg -i ripgrep_13.0.0_amd64.deb
 
     - uses: actions/checkout@v2
     - name: Test


### PR DESCRIPTION
CI currently pins ripgrep 12.1.1 (2020). This bumps it one major version to 13.0.0 as a modest step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwUBSSJnCtCeoqJEA3xH48