### PR TITLE
Remove a duplicated setq in deadgrep--stop-and-reset

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1570,7 +1570,6 @@ matches (if the result line has been truncated)."
     (setq deadgrep--current-file nil)
     (setq deadgrep--spinner nil)
     (setq deadgrep--remaining-output nil)
-    (setq deadgrep--current-file nil)
     (setq deadgrep--debug-first-output nil)
     (setq deadgrep--imenu-alist nil)))
 


### PR DESCRIPTION
`deadgrep--stop-and-reset` set `deadgrep--current-file` to nil twice; this removes the second assignment. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwUBSSJnCtCeoqJEA3xH48

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwUBSSJnCtCeoqJEA3xH48)_